### PR TITLE
Update SPLASH SC details.

### DIFF
--- a/Committees/X.html
+++ b/Committees/X.html
@@ -29,7 +29,7 @@
 </tr>
 <tr class="even">
 <td align="left">ISMM</td>
-<td align="left">Vechev Martin</td>
+<td align="left">Christine Flood</td>
 </tr>
 <tr class="odd">
 <td align="left">LCTES</td>
@@ -53,7 +53,7 @@
 </tr>
 <tr class="even">
 <td align="left">SPLASH</td>
-<td align="left">Crista Lopes</td>
+<td align="left">Antony Hosking</td>
 </tr>
 <tr class="odd">
 <td align="left">VEE</td>

--- a/Conferences/SPLASH.md
+++ b/Conferences/SPLASH.md
@@ -27,9 +27,8 @@ among the members of the committee to serve a two-year term.  The outgoing
 chair serves an additional year on the committee past his or her term as chair
 to provide institutional memory.
 
-The constitution of the steering committee changes each year on October 31,
-with the SPLASH chair changing every two years and the SIGPLAN chair/vice
-chair changing every third year.
+The constitution of the steering committee changes each year upon conclusion
+of that year's conference.
 
 The current SPLASH steering committee is:
 

--- a/_data/Committees.yaml
+++ b/_data/Committees.yaml
@@ -180,12 +180,13 @@ SPLASH Steering Committee:
   -  Andrew Black, 2014 SPLASH General Chair
   -  Todd Millstein, 2014 OOPSLA PC Chair
   -  Shriram Krishnamurthi, 2014 Onward! Papers Chair
-  -  Jonathan Aldrich, 2015 SPLASH General Chair
   -  Patrick Eugster, 2015 OOPSLA PC Chair and 2013 SPLASH General Co-Chair
-  -  Gail Murphy, 2015 Onward! Papers Chair
   -  Eelco Visser, 2016 SPLASH General Chair
   -  Yannis Smaragdakis, 2016 OOPSLA PC Chair
   -  Emerson Murphy-Hill, 2016 Onward! PC Chair
+  -  Gail Murphy, 2017 SPLASH General Chair and 2015 Onward! Papers Chair
+  -  Jonathan Aldrich, 2017 OOPSLA PC Chair and 2015 SPLASH General Chair
+  -  Emina Torlak, 2017 Onward! PC Chair
 
 "VEE Steering Committee":
   -  Chair: "[Martin Hirzel](http://hirzels.com/martin/)       (IBM Research)"


### PR DESCRIPTION
The constitution of the SPLASH SC has changed with approval of the SC (and SIGPLAN EC via SIGPLAN Chair and VC) to accommodate years in which the conference is held later than October.

I also updated the current members of the SC for ISMM and SPLASH.