### PR TITLE
ISMM SC rotation

### DIFF
--- a/Committees/SCChairs.md
+++ b/Committees/SCChairs.md
@@ -7,7 +7,7 @@ DLS                 | Carl Friedrich Bolz   |
 GPCE                | Eelco Visser          |
 Haskell             | Koen Claessen         |
 ICFP                | Peter Thiemann        |
-ISMM                | Christine Flood       |
+ISMM                | Christoph Kirsch      |
 LCTES               | Bruce Childers        |
 PEPM                | Oleg Kiselyov         | PEPM is not reprinted in SIGPLAN
 PLDI                | Kathleen Fisher       |

--- a/_data/Committees.yaml
+++ b/_data/Committees.yaml
@@ -107,12 +107,10 @@ ICFP Steering Committee:
 
 ISMM Steering Committee:
   -   "[Mike Bond](http://web.cse.ohio-state.edu/~mikebond)"
-  -   "[Perry Cheng](http://researcher.watson.ibm.com/researcher/view.php?person=us-perry)"
-  - Chair: Christine Flood (Red Hat)
-  -   "[Samuel Guyer](http://www.cs.tufts.edu/~sguyer)"
-  -   "[David Grove](http://researcher.ibm.com/view.php?person=us-groved)"
+  -   Christine Flood (Red Hat)
   -   "[Tony Hosking](http://www.cs.purdue.edu/~hosking)"
-  -   "[Erez Petrank](http://www.cs.technion.ac.il/~erez/)"
+  - Chair: "[Christoph Kirsch](http://www.cs.uni-salzburg.at/~ck)"
+  -   Ben Titzer (Google)
   -   "[Zheng Zhang](http://www.cs.rutgers.edu/~zz124/)"
 
 


### PR DESCRIPTION
ISMM'17 is now past; update steering committee membership according to ISMM bylaws.

