### PR TITLE
Word is not supported (ACM mentions only an 'interim' template)

### DIFF
--- a/Resources/Author.md
+++ b/Resources/Author.md
@@ -67,7 +67,7 @@ The `screen` option adds colors to hyperlinks and cross references.
 
 ### Microsoft Word
 
-The `acmart` format is not supported by Microsoft Word.
+The `acmart` format is not supported by Microsoft Word. [2020-03-21]
 
 - - -
 

--- a/Resources/Author.md
+++ b/Resources/Author.md
@@ -67,7 +67,7 @@ The `screen` option adds colors to hyperlinks and cross references.
 
 ### Microsoft Word
 
-The `acmart` format is not supported by Microsoft Word. [2020-03-21]
+The `acmart` format is not supported by Microsoft Word, as of March 2020.
 
 - - -
 

--- a/Resources/Author.md
+++ b/Resources/Author.md
@@ -65,11 +65,9 @@ typesetting.)
 
 The `screen` option adds colors to hyperlinks and cross references.
 
-### Word templates
+### Microsoft Word
 
-For Word users, the `acmart` format is available from ACM's [Master
-Article
-Template](http://www.acm.org/publications/proceedings-template) page.
+The `acmart` format is not supported by Microsoft Word.
 
 - - -
 


### PR DESCRIPTION
Remove the statement that there is a Word template available on the ACM's template web site.
It only states that there is some interim version of a template.
[http://www.acm.org/publications/proceedings-template, 2020-03-21]

Fixes #142 