### PR TITLE
Update SIGPLAN-M website for 2022

### DIFF
--- a/LongTermMentoring.md
+++ b/LongTermMentoring.md
@@ -14,23 +14,31 @@ and to access the perspectives of researchers from other institutions.
 
 In response to these needs, SIGPLAN-M matches mentors with mentees from different institutions
 for mentoring relationships that last at least a year.
-As of July, 2021, there are more than 380 mentees and 220 mentors participating in the program.
+As of April, 2022, there are more than 320 mentees and 220 mentors participating in the program.
 Here are some testimonials from mentees:
 
-> Having someone to talk to about my future has been one of the few good highlights of 2020.
-> It has made feel like there might be good things in the future, not just bad ones.
+> [SIGPLAN-M is] a career saver!
 
-> As a beginning grad student having limited interaction with my new department because of
-> COVID, the mentorship program gives me the outside perspective (beyond my research group)
-> that I would otherwise be missing.
+> [My mentor] is incredible AND the only person I talk to regularly who has an interest in the same topics that I do. Talking with [my mentor] gives me a sense of community that I hadn't had before.
+ 
+> [SIGPLAN-M] was life changing.
+
+> I wouldn't be able to obtain technical feedback for my work if SIGPLAN-M did not exist.
+ 
+> Just talking to [my mentor] is incredibly validating. [My mentor's] support means the world to me.
+ 
+> My mentor is amazing... Also, they made me think differently (in a positive way) about Academia and made me want to stay :).
+ 
+> I had no idea what I was doing before, but now I have a pretty good idea of what to work on and a better sense of if I'm doing the right things/enough for grad school applications.
+ 
+> I got help in all aspects - from research to getting through [a] graduate program.
 
 Check out our [Twitter](https://twitter.com/SigplanM) for the latest news!
 
-## Committee Members for 2021
+## Committee Members for 2022
 
 - **Operations Team**: [Reshabh Sharma](https://www.linkedin.com/in/reshabh/), [Kimaya Bedarkar](https://in.linkedin.com/in/kimaya-bedarkar-694933171), [Sabree Blackmon](https://www.linkedin.com/in/sabree-blackmon), [Yanze Li](https://liyz.pl/), [Ian Sweet](https://www.impredicative.org/), [Umang Mathur](http://umathur3.web.engr.illinois.edu/), [Heiko Becker](https://people.mpi-sws.org/~hbecker/)
 - **Advisory Board**: [Alexandra Silva](https://alexandrasilva.org/), [David Van Horn](https://www.cs.umd.edu/~dvanhorn/), [Dimitrios Vytiniotis](https://dimitriv.github.io/), [Sebastian Erdweg](https://www.pl.informatik.uni-mainz.de/), [Steve Blackburn](http://users.cecs.anu.edu.au/~steveb/), [Sukyoung Ryu](https://plrg.kaist.ac.kr/ryu)
-
 - **Chair**: [Talia Ringer](https://dependenttyp.es/)
 
 ## Getting Involved

--- a/LongTermMentoring.md
+++ b/LongTermMentoring.md
@@ -69,3 +69,45 @@ Examples of urgent needs for mentoring include but are not limited to
 mental health struggles, advisor-advisee conflicts, ongoing job or graduate school applications, and abusive situations at work or in the community.
 If any of these apply, and if you are comfortable doing so, please feel free to contact us so that we match you in a timely fashion.
 
+## Thank You, Mentors!
+
+We really appreciate all of our mentors for the amazing work they do---and we want the world to know how much we appreciate it!
+Here is a list of some of our amazing mentors. If you are already a mentor for us, and you're welcome to being thanked publicly,
+please let us know and we'll happily add you to this list!
+
+We'd like to thank these amazing mentors:
+- Jonathan Aldrich
+- Stavros Aronis
+- Tom Ball
+- Sheng Chen
+- Alastair Donaldson
+- Sebastian Erdweg
+- Tobias Grosser
+- Jason Hemann
+- Kuen-Bang Hou (Favonia) 
+- Ralf Jung
+- Konstantinos Kallas
+- Raffi Khatchadourian
+- Kalyan Krishnamani
+- Shriram Krishnamurthi
+- Patrick Lam
+- John Leo
+- William Mansky
+- Andrey Mokhov
+- Joe Politz
+- Kia Rahmani
+- Norman Ramsey
+- Talia Ringer
+- Roopsha Samanta
+- Mike Samuel
+- Gus Smith
+- Caleb Stanford
+- Simon Thompson
+- Dimitris Vardoulakis
+- John Wickerson
+- James Wilcox
+- Li-yao Xia
+
+And we'd of course also like to thank everyone else who has served or currently serves as a mentor for SIGPLAN-M!
+
+Your service makes a huge difference in the careers and lives of our mentees. SIGPLAN is better off for having you.


### PR DESCRIPTION
1. Update SIGPLAN-M website with 2022 numbers and anecdotes
2. Add list of mentors who consented to being thanked on the website