### PR TITLE
Update MPLR and DLS Steering Committees

### DIFF
--- a/_data/Committees.yaml
+++ b/_data/Committees.yaml
@@ -128,15 +128,13 @@ LCTES Steering Committee:
   - Zheng Zhang, Rutgers University
 
 MPLR Steering Committee:
-  - Chair: "[Hanspeter Mössenböck](https://ssw.jku.at/General/Staff/HM/)"
-  - "[Walter Binder](https://www.inf.usi.ch/faculty/binder/)"
+  - Chair: "[Stefan Marr](https://www.kent.ac.uk/computing/people/3167/marr-stefan)"
   - "[Tony Hosking](https://cecs.anu.edu.au/people/tony-hosking)"
   - "[Christos Kotselidis](https://www.kotselidis.net/)"
   - "[Herbert Kuchen](https://www.wi.uni-muenster.de/department/pi/people/herbert-kuchen)"
-  - "[Stefan Marr](https://www.kent.ac.uk/computing/people/3167/marr-stefan)"
-  - "[Martin Plümicke](https://www.dhbw-stuttgart.de/horb/studium/bachelor-studienangebot/informatik/ansprechpersonen/prof-dr-rer-nat-martin-pluemicke)"
   - "[Jeremy Singer](http://www.dcs.gla.ac.uk/~jsinger)"
-  - "[Petr Tuma](https://d3s.mff.cuni.cz/people/petrtuma)"
+  - "[Elisa Gonzalez Boix](https://soft.vub.ac.be/disco/elisa/)"
+  - "[Tobias Wrigstad](https://www.it.uu.se/katalog/writo649)"
 
 Onward! Steering Committee:
     - Chair: Jonathan Aldrich

--- a/_data/Committees.yaml
+++ b/_data/Committees.yaml
@@ -81,13 +81,13 @@ CGO Steering Committee:
   - Jingling Xue, UNSW
 
 DLS Steering Committee:
-    - Chair: Tim Felgentreff
-    - Davide Ancona
+    - Chair: "[Stefan Marr](https://www.kent.ac.uk/computing/people/3167/marr-stefan)"
+    - Tim Felgentreff
     - Carl Friedrich Bolz-Tereick
+    - Matthew Flatt
+    - Arjun Guha
     - Robert Hirschfeld
-    - Stefan Marr
-    - Benjamin C. Pierce
-    - Laurence Tratt
+    - Anders Møller
 
 FOOL Steering Committee:
 


### PR DESCRIPTION
This PR updates the current Steering Committees for MPLR and DLS.

The MPLR update is a yearly update (first committee).
The DLS one, I noticed as being outdated too and is now brought in line with https://dynamic-languages-symposium.org/

@jeremysinger I think Peter asked you for this, so, I think this PR should take care of it.