### PR TITLE
Introduce Rematching Coordinator role

### DIFF
--- a/LongTermMentoring.md
+++ b/LongTermMentoring.md
@@ -37,7 +37,8 @@ Check out our [Twitter](https://twitter.com/SigplanM) for the latest news! You c
 
 ## Committee Members
 
-- **Operations Team**: [Reshabh Sharma](https://www.linkedin.com/in/reshabh/), [Ronak Chauhan](https://in.linkedin.com/in/ronchauhan), [Yannick Forster](https://yforster.github.io/), [Shraddha Barke](https://shraddhabarke.github.io/), [Kiran Gopinathan](https://gopiandcode.uk/), [Yunjeong Lee](http://www.leeyunjeong.com/), [Jialu Bao](https://baojia.lu/about/), [Jocelyn Chen](https://www.cs.utexas.edu/~qchen/)
+- **Operations Team**: [Reshabh Sharma](https://www.linkedin.com/in/reshabh/), [Ronak Chauhan](https://in.linkedin.com/in/ronchauhan), [Yannick Forster](https://yforster.github.io/), [Shraddha Barke](https://shraddhabarke.github.io/), [Kiran Gopinathan](https://gopiandcode.uk/), [Yunjeong Lee](http://www.leeyunjeong.com/), [Jialu Bao](https://baojia.lu/about/)
+- **Rematching Coordinator**: [Jocelyn Chen](https://www.cs.utexas.edu/~qchen/)
 - **Advisory Board**: [Alexandra Silva](https://alexandrasilva.org/), [David Van Horn](https://www.cs.umd.edu/~dvanhorn/), [Dimitrios Vytiniotis](https://dimitriv.github.io/), [Sebastian Erdweg](https://www.pl.informatik.uni-mainz.de/), [Steve Blackburn](http://users.cecs.anu.edu.au/~steveb/), [Sukyoung Ryu](https://plrg.kaist.ac.kr/ryu)
 - **Chair**:  [Nadia Polikarpova](https://cseweb.ucsd.edu/~npolikarpova/)
 - **Previous Chair**: [Talia Ringer](https://dependenttyp.es/)


### PR DESCRIPTION
Over the next couple of months we will be giving more specialized roles to some of the ops members. This is the first of these changes.