### PR TITLE
update SPLASH SC list

### DIFF
--- a/_data/Committees.yaml
+++ b/_data/Committees.yaml
@@ -198,18 +198,18 @@ SPLASH Steering Committee:
   - SIGPLAN Vice Chair: #
   - Chair: David Grove, IBM Research
   - Amal Ahmed, Northeastern University
+  - Bor-Yuh Evan Chang, University of Colorado Boulder
   - Wolfgang De Meuter, Vrije Universiteit Brussel
   - Sophia Drossopoulou, Imperial College London
-  - Jeff Foster, Tufts University
   - Antony Hosking, Australian National University
   - Stephen Kell, King's College London
   - Shriram Krishnamurthi, Brown
   - Hidehiko Masuhara, Tokyo Institute of Technology
   - Manu Sridharan, UC Riverside
   - Mira Mezini, TU Darmstadt
-  - Anders Møller, Aarhus University
   - Alex Potanin, Victoria University of Wellington
   - Hridesh Rajan, Iowa State University
+  - Sukyoung Ryu, Korea Advanced Institute of Science and Technology
   - Yannis Smaragdakis, University of Athens
   - Vasco T. Vasconcelos, University of Lisbon
   - Jan Vitek, Northeastern University / Czech Technical University


### PR DESCRIPTION
Jeff and Anders will be pulled in automatically via CHAIR/VICE CHAIR mechanism.
Adding co-chairs for OOPLSA'24 (Evan) and OOPSLA'25 (Sukyoung)