### PR TITLE
Distinguish in-cooperation & inactive events

### DIFF
--- a/Conferences.md
+++ b/Conferences.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: "SIGPLAN Conferences"
+title: "SIGPLAN Conferences & Workshops"
 ---
 SIGPLAN organizes the
 premier conferences and workshops in the area of programming language
@@ -27,6 +27,12 @@ The conferences listed below are regularly sponsored by
 SIGPLAN. 
 
 {% for conf in site.data.Conferences %}
-**[{{conf.name}}]({{conf.link}})**  
+**[{{conf.name}}]({{conf.link}})**
+{%- if conf.inactive %}
+ (inactive)
+{%- endif -%}
+{%- if conf.cooperation %}
+ (in-cooperation)
+{%- endif %}  
 {{conf.description}}
 {% endfor %}

--- a/_data/Conferences.yaml
+++ b/_data/Conferences.yaml
@@ -96,6 +96,7 @@
     static to fully dynamic approaches, including techniques ranging
     from pure software-based methods to architectural features and
     support.
+    CGO is co-sponsored with [SIGMICRO](https://www.sigmicro.org).
 
 -
   name: Dynamic Languages Symposium (DLS)
@@ -134,6 +135,7 @@
     expose researchers and developers from either area to relevant work
     and interesting problems in the other area and provide a forum
     where they can interact.
+    LCTES is co-sponsored with [SIGBED](https://sigbed.org).
 
 -
   name: Haskell Symposium (HS)

--- a/_data/Conferences.yaml
+++ b/_data/Conferences.yaml
@@ -231,3 +231,13 @@
     verification and certification as an essential paradigm for their work.
     CPP spans areas of computer science, mathematics, logic, and education.
   cooperation: true
+
+-
+  name: International Conference on the Art, Science, and Engineering of Programming (‹Programming›)
+  link: https://programming-conference.org
+  description: |
+    ‹Programming› is a new conference focused on everything to do with
+    programming including the experience of programming. Papers are welcome
+    from any part of the programming research lifecycle, as are papers on
+    programming practice and experience.
+  cooperation: true

--- a/_data/Conferences.yaml
+++ b/_data/Conferences.yaml
@@ -5,10 +5,14 @@
 #       (E.g., should CGO be included?  Should CC?)  How should the list be
 #       sorted? -->
 #
-# <!-- (AF) What does "regularly" mean? Permanently? If I remember correctly we 
+# <!-- (AF) What does "regularly" mean? Permanently? If I remember correctly we
 #       issued CC a 2-3 year sponsorship to be revisited later. Is that "regular"?
 #       Also, I don't have a way of checking the list, other than sending an
 #       email to everyone to report discrepancies. Shall we? -->
+#
+# <!-- (AS) I have now distinguished between "sponsored" (including
+#      co-sponsored) and "in-cooperation" conferences so we can display the
+#      lists separately. See the `cooperation` key. -->
 
 -
   name: Principles of Programming Languages (POPL)
@@ -99,6 +103,7 @@
   description: |
     The Dynamic Languages Symposium (DLS) is a forum for discussion of
     dynamic languages, their implementation, and application.
+  inactive: true
 
 -
   name: 'Generative Programming: Concepts and Experiences (GPCE)'
@@ -201,6 +206,7 @@
     among a number of different venues in the languages (VM, PLDI,
     OOPSLA, IVME), operating systems (SOSP, OSDI, USENIX), and
     architecture (ASPLOS, CGO, PACT) communities.
+  inactive: true
 
 -
   name: The Programming Languages Mentoring Workshop (PLMW)
@@ -224,3 +230,4 @@
     practical and theoretical topics in all areas that consider formal
     verification and certification as an essential paradigm for their work.
     CPP spans areas of computer science, mathematics, logic, and education.
+  cooperation: true

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -92,10 +92,16 @@
 
           {% endfor %}
 
-          <h3>SIGPLAN Sponsored <a href="/Conferences/">Conferences</a></h3>
+          <h3>SIGPLAN <a href="/Conferences/">Events</a></h3>
           <ul>
           {% for conf in site.data.Conferences %}
-              <li><a href="{{conf.link}}">{{conf.name}}</a></li>
+              {% if conf.inactive != true %}
+              <li><a href="{{conf.link}}">{{conf.name}}</a>
+                  {% if conf.cooperation %}
+                  (in-cooperation)
+                  {% endif %}
+              </li>
+              {% endif %}
           {% endfor %}
           </ul>
         </div>


### PR DESCRIPTION
In our list of SIGPLAN events (conferences + workshops), we now have extra metadata to say:

* Is this an "in-cooperation" event (as opposed to a SIGPLAN-sponsored event)?
* Is this event currently inactive?

I don't know yet whether we've caught all the events this should apply to, but we've caught one in-cooperation event (CPP) and two inactive events (VEE and DLS). We can separately keep looking for other events to apply this to.

The data shows up in two different ways. On the homepage, we exclude inactive events and mark in-cooperation events. It looks like this:

<img width="660" height="456" alt="Screenshot 2026-06-04 at 5 07 45 PM" src="https://github.com/user-attachments/assets/27a9867a-976f-4370-9a7f-d05d38eac07e" />

If we ever have more than one in-cooperation event, maybe it will make sense to have separate "sponsored" and "in-cooperation" lists instead.

On the [main "Conferences" page](https://www.sigplan.org/Conferences/) (now renamed "Conferences & Workshops"), we just mark both inactive and in-cooperation events but otherwise keep the layout the same.

(Paging @amoeller, who brought up this set of issues.)